### PR TITLE
[Docs] Remove install-template target from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ govulncheck-install   ## Install govulncheck
 help                  ## Display this help message
 install-go            ## Install using go install with specific version
 install-releaser      ## Install GoReleaser
-install-template      ## Kick-start a fresh copy of go-safe-conversion (run once!)
 install               ## Install the application binary
 lint                  ## Run the golangci-lint application (install if not found)
 release-snap          ## Build snapshot binaries


### PR DESCRIPTION
#### What Changed
- Removed the `install-template` make target from the README command list

#### Why It Was Necessary
- The command is no longer used and created confusion when following README instructions

#### Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

#### Impact / Risk
- No code changes were made; documentation update only. Risk is minimal.

------
https://chatgpt.com/codex/tasks/task_e_6866b6e0bec08321bcd058c4e0409d19