### PR TITLE
[Repo] Add CODEOWNERS entries for config files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 
 # GitHub Actions workflows
 .github/workflows/* @mrz1836
+.github/.env.shared @mrz1836
 
 # Documentation files
 *.md @mrz1836
@@ -19,3 +20,13 @@ Makefile @mrz1836
 # Go module dependencies
 go.mod @mrz1836
 go.sum @mrz1836
+
+# AI Config Files
+.github/AGENTS.md @mrz1836
+.cursorrules @mrz1836
+.github/CLAUDE.md @mrz1836
+sweep.yml @mrz1836
+
+# Repository configuration
+.github/labels.yml @mrz1836
+.github/dependabot.yml @mrz1836


### PR DESCRIPTION
## What Changed
- expanded CODEOWNERS with environment file, AI configuration files and repository configuration entries

## Why It Was Necessary
- ensure ownership for new config and workflow files

## Testing Performed
- `go fmt ./...`
- `goimports -w .`
- `gofumpt -w .`
- `golangci-lint run` *(failed: unknown linters)*
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no functional code changes
- minimal risk of merge conflicts

cc @mrz1836

------
https://chatgpt.com/codex/tasks/task_e_6878f309f0488321a8d7089fa17e6dd0